### PR TITLE
Add requirements list file for python module package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pyzmq>=16.0.2
+jinja2>=2.9.5
+pandas>=0.19.2
+tornado>=4.4.2
+ipython==3.2.0
+jsonschema>=2.5.1


### PR DESCRIPTION
I added requirements file for install python modules. It could change `pip install pyzmq jinja2 pandas tornado ipython==3.2.0 jsonschema` to `pip install -r requirements.txt`.
Please look on.